### PR TITLE
feat/styled-component-react-import

### DIFF
--- a/src/generators/react/template/index.ts
+++ b/src/generators/react/template/index.ts
@@ -1,11 +1,12 @@
 export const TEMPLATES = {
   index: `import React from 'react'
+import * as S from './styles'
   
 const @name@ = () => {
   return (
-    <div testid="@camelCaseName@">
+    <S.Wrapper data-testid="@camelCaseName@">
       @name@ component
-    </div>
+    </S.Wrapper>
   )
 }
   
@@ -13,17 +14,17 @@ export default @name@`,
 
   style: `import styled from 'styled-components'
 
-export const @name@Wrapper = styled.div\`
+export const Wrapper = styled.div\`
 \``,
   test: `import React from 'react'
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import @name@ from '.'
 
 describe('<@name@ />', () => {
   it('should render the component', () => {
-    const element = render(<@name@ />)
+    render(<@name@ />)
 
-    expect(element.getByText('@name@ component')).toBeInTheDocument()
+    expect(screen.getByTestId("@camelCaseName@")).toBeInTheDocument()
   })
 })
   `,


### PR DESCRIPTION
**What changes**  (closes #7 [here](https://github.com/juntossomosmais/jsm-component-generator/issues/7))

- Rename import of styled component in React Generator to `* as S`
- Change `testid` to `data-testid`
- Create initial test based in Wrapper `data-testid`

**Evidencies**

https://user-images.githubusercontent.com/75763403/184271874-f949e273-0cb4-4016-862d-b90ee18daaed.mp4